### PR TITLE
Fixed error "/bitnami/postgresql/data/postgresql.conf": No such file …

### DIFF
--- a/10/debian-10/rootfs/librepmgr.sh
+++ b/10/debian-10/rootfs/librepmgr.sh
@@ -491,6 +491,7 @@ log_level='${REPMGR_LOG_LEVEL}'
 priority='${REPMGR_NODE_PRIORITY}'
 degraded_monitoring_timeout='${REPMGR_DEGRADED_MONITORING_TIMEOUT}'
 data_directory='${POSTGRESQL_DATA_DIR}'
+pg_ctl_options='-l $POSTGRESQL_LOG_FILE -o --config-file="$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE"'
 async_query_timeout='${REPMGR_MASTER_RESPONSE_TIMEOUT}'
 EOF
     fi

--- a/11/debian-10/rootfs/librepmgr.sh
+++ b/11/debian-10/rootfs/librepmgr.sh
@@ -491,6 +491,7 @@ log_level='${REPMGR_LOG_LEVEL}'
 priority='${REPMGR_NODE_PRIORITY}'
 degraded_monitoring_timeout='${REPMGR_DEGRADED_MONITORING_TIMEOUT}'
 data_directory='${POSTGRESQL_DATA_DIR}'
+pg_ctl_options='-l $POSTGRESQL_LOG_FILE -o --config-file="$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE"'
 async_query_timeout='${REPMGR_MASTER_RESPONSE_TIMEOUT}'
 EOF
     fi

--- a/12/debian-10/rootfs/librepmgr.sh
+++ b/12/debian-10/rootfs/librepmgr.sh
@@ -491,6 +491,7 @@ log_level='${REPMGR_LOG_LEVEL}'
 priority='${REPMGR_NODE_PRIORITY}'
 degraded_monitoring_timeout='${REPMGR_DEGRADED_MONITORING_TIMEOUT}'
 data_directory='${POSTGRESQL_DATA_DIR}'
+pg_ctl_options='-l $POSTGRESQL_LOG_FILE -o --config-file="$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE"'
 async_query_timeout='${REPMGR_MASTER_RESPONSE_TIMEOUT}'
 EOF
     fi

--- a/9.6/debian-10/rootfs/librepmgr.sh
+++ b/9.6/debian-10/rootfs/librepmgr.sh
@@ -491,6 +491,7 @@ log_level='${REPMGR_LOG_LEVEL}'
 priority='${REPMGR_NODE_PRIORITY}'
 degraded_monitoring_timeout='${REPMGR_DEGRADED_MONITORING_TIMEOUT}'
 data_directory='${POSTGRESQL_DATA_DIR}'
+pg_ctl_options='-l $POSTGRESQL_LOG_FILE -o --config-file="$POSTGRESQL_CONF_FILE --external_pid_file=$POSTGRESQL_PID_FILE --hba_file=$POSTGRESQL_PGHBA_FILE"'
 async_query_timeout='${REPMGR_MASTER_RESPONSE_TIMEOUT}'
 EOF
     fi


### PR DESCRIPTION
This PR fixes an error `"/bitnami/postgresql/data/postgresql.conf": No such file or directory` - it appears when we have more than 2 nodes and the primary one died.
(command `repmgr` uses `pg_ctl` inside and configures that using `pg_ctl_options` from `repmgr.conf`)


I tested this using docker-compose.yml:
```
version: '2'
services:
  pg-0:
    image: bitnami/postgresql-repmgr:12
    ports:
      - 5432
    volumes:
      - pg_0_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - POSTGRESQL_REPLICATION_USER=postgres
      - POSTGRESQL_REPLICATION_PASSWORD=adminpassword
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=pg-0
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432,pg-2:5432
      - REPMGR_NODE_NAME=pg-0
      - REPMGR_NODE_NETWORK_NAME=pg-0
      - REPMGR_PORT_NUMBER=5432
      - BITNAMI_DEBUG=true
      - REPMGR_LOG_LEVEL=DEBUG
  pg-1:
    image: bitnami/postgresql-repmgr:12
    ports:
      - 5432
    volumes:
      - pg_1_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - POSTGRESQL_REPLICATION_USER=postgres
      - POSTGRESQL_REPLICATION_PASSWORD=adminpassword
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=pg-0
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432,pg-2:5432
      - REPMGR_NODE_NAME=pg-1
      - REPMGR_NODE_NETWORK_NAME=pg-1
      - REPMGR_PORT_NUMBER=5432
      - BITNAMI_DEBUG=true
      - REPMGR_LOG_LEVEL=DEBUG
  pg-2:
    image: bitnami/postgresql-repmgr:12
    ports:
      - 5432
    volumes:
      - pg_2_data:/bitnami/postgresql
    environment:
      - POSTGRESQL_POSTGRES_PASSWORD=adminpassword
      - POSTGRESQL_USERNAME=customuser
      - POSTGRESQL_PASSWORD=custompassword
      - POSTGRESQL_DATABASE=customdatabase
      - POSTGRESQL_REPLICATION_USER=postgres
      - POSTGRESQL_REPLICATION_PASSWORD=adminpassword
      - REPMGR_PASSWORD=repmgrpassword
      - REPMGR_PRIMARY_HOST=pg-0
      - REPMGR_PRIMARY_PORT=5432
      - REPMGR_PARTNER_NODES=pg-0,pg-1:5432,pg-2:5432
      - REPMGR_NODE_NAME=pg-2
      - REPMGR_NODE_NETWORK_NAME=pg-2
      - REPMGR_PORT_NUMBER=5432
      - BITNAMI_DEBUG=true
      - REPMGR_LOG_LEVEL=DEBUG
volumes:
  pg_0_data:
    driver: local
  pg_1_data:
    driver: local
  pg_2_data:
    driver: local

```


After run the compose file, execute command(s):
```
echo 'Creating user which is needed by repmgr command.'; \
docker exec -u root -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'useradd -b /opt -m -s /bin/bash repmgr -u 1001 && chown -R repmgr:100 /opt/bitnami/*/tmp' && \
docker exec -u root -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'useradd -b /opt -m -s /bin/bash repmgr -u 1001 && chown -R repmgr:100 /opt/bitnami/*/tmp' && \
docker exec -u root -it bitnami-docker-postgresql-repmgr_pg-2_1 bash -c 'useradd -b /opt -m -s /bin/bash repmgr -u 1001 && chown -R repmgr:100 /opt/bitnami/*/tmp' && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Stopping server 0.'; \
docker stop bitnami-docker-postgresql-repmgr_pg-0_1 && \
\
sleep 30s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-1_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Starting server 0.'; \
docker start bitnami-docker-postgresql-repmgr_pg-0_1 && \
\
sleep 15s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Stopping server 1.'; \
docker stop bitnami-docker-postgresql-repmgr_pg-1_1 && \
\
sleep 15s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'; \
\
sleep 5s && \
\
echo 'Starting server 1.'; \
docker start bitnami-docker-postgresql-repmgr_pg-1_1 && \
\
sleep 30s && \
\
echo 'Checking status.'; \
docker exec -it bitnami-docker-postgresql-repmgr_pg-0_1 bash -c 'repmgr -f /opt/bitnami/repmgr/conf/repmgr.conf cluster show'

```